### PR TITLE
Return tuple updates

### DIFF
--- a/biosppy/utils.py
+++ b/biosppy/utils.py
@@ -512,7 +512,7 @@ class ReturnTuple(tuple):
 
         """
 
-        if isinstance(new_tuple, ReturnTuple):
+        if not isinstance(new_tuple, ReturnTuple):
             raise TypeError('new_tuple must be a ReturnTuple object.')
 
         values = self + new_tuple

--- a/biosppy/utils.py
+++ b/biosppy/utils.py
@@ -519,3 +519,35 @@ class ReturnTuple(tuple):
         keys = tuple(self.keys()) + tuple(new_tuple.keys())
 
         return ReturnTuple(values, keys)
+
+    def delete(self, key):
+        """
+        Returns a ReturnTuple without the specified key.
+
+        Parameters
+        ----------
+        key : str
+            ReturnTuple key to be deleted.
+
+        Returns
+        -------
+        object : ReturnTuple
+            The ReturnTuple with the key removed.
+
+        """
+        values = tuple()
+        keys = tuple()
+
+        if not isinstance(key, str):
+            raise TypeError('key must be a string.')
+
+        if key not in self.keys():
+            raise ValueError(f'{key} key not in the ReturnTuple.')
+
+        for k in self.keys():
+
+            if k != key:
+                values += (self.__getitem__(k), )
+                keys += (k, )
+
+        return ReturnTuple(values, keys)


### PR DESCRIPTION
Updates the ReturnTuple object with one new method:

.delete(key) that creates a new ReturnTuple without the specified key.

It also fixes the join method.