### PR TITLE
Warn even kernel size instead of halting

### DIFF
--- a/biosppy/signals/tools.py
+++ b/biosppy/signals/tools.py
@@ -589,7 +589,8 @@ def smoother(signal=None, kernel="boxzen", size=10, mirror=True, **kwargs):
         elif kernel == "median":
             # median filter
             if size % 2 == 0:
-                raise ValueError("When the kernel is 'median', size must be odd.")
+                size -= 1
+                raise Warning("When the kernel is 'median', size must be odd, so the size was decremented by one.")
 
             smoothed = ss.medfilt(signal, kernel_size=size)
 


### PR DESCRIPTION
Wouldn't it be more friendly if BioSPPy solved for the user the issue of passing an even kernel size when median filtering? Because raising an error halts the program, which isn't necessary since it's not problematic. Here's a proposal to solve the issue and alert the user.