### PR TITLE
Improve ECG filtering in ecg.ecg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 ```
+✨️ Update: The ECG preprocessing pipeline has been improved! (Check PR #12)
+```
+
+```
 🎉 New feature: We just added the Notch filter to the list of supported filters!
 ```
 

--- a/biosppy/signals/ecg.py
+++ b/biosppy/signals/ecg.py
@@ -86,7 +86,7 @@ def ecg(signal=None, sampling_rate=1000.0, path=None, show=True, interactive=Tru
         sampling_rate=sampling_rate,
     )
 
-    filtered = filtered - np.mean(filtered)
+    filtered = filtered - np.mean(filtered)  # remove DC offset
 
     # segment
     (rpeaks,) = hamilton_segmenter(signal=filtered, sampling_rate=sampling_rate)

--- a/biosppy/signals/ecg.py
+++ b/biosppy/signals/ecg.py
@@ -82,9 +82,11 @@ def ecg(signal=None, sampling_rate=1000.0, path=None, show=True, interactive=Tru
         ftype="FIR",
         band="bandpass",
         order=order,
-        frequency=[3, 45],
+        frequency=[0.5, 45],
         sampling_rate=sampling_rate,
     )
+
+    filtered = filtered - np.mean(filtered)
 
     # segment
     (rpeaks,) = hamilton_segmenter(signal=filtered, sampling_rate=sampling_rate)

--- a/biosppy/signals/ecg.py
+++ b/biosppy/signals/ecg.py
@@ -76,13 +76,13 @@ def ecg(signal=None, sampling_rate=1000.0, path=None, show=True, interactive=Tru
     sampling_rate = float(sampling_rate)
 
     # filter signal
-    order = int(0.3 * sampling_rate)
+    order = int(1.5 * sampling_rate)
     filtered, _, _ = st.filter_signal(
         signal=signal,
         ftype="FIR",
         band="bandpass",
         order=order,
-        frequency=[0.5, 45],
+        frequency=[0.67, 45],
         sampling_rate=sampling_rate,
     )
 


### PR DESCRIPTION
The current bandpass filter in ecg.ecg has cutoff frequencies between 3 and 45 Hz. The 3 Hz cutoff significantly alters or even removes some important features from the signal (such as the P and T waves).

I propose changing the lower cutoff frequency to 0.5 Hz. Since this new filter doesn't remove the signal's DC component, it is necessary to subtract the mean from the signal after filtering.