### PR TITLE
Add Zenodo DOI & change release trigger

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,7 @@ name: Publish Python 🐍 distribution 📦 to PyPI
 on: 
   push:
       tags:
-       - '*'
+        - 'v*'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ P. Bota, R. Silva, C. Carreiras, A. Fred, and H. P. da Silva, "BioSPPy: A Python
 
 However, if you want to cite a specific version of BioSPPy, you can use Zenodo's DOI:
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11048615.svg)](https://doi.org/10.5281/zenodo.11048615)
+
+
 ## License
 BioSPPy is released under the BSD 3-clause license. See LICENSE for more details.
 


### PR DESCRIPTION
Minor changes associated with the latest release:

- Adds newly generated DOI for the current version in Zenodo
- Changes trigger release only with secure tags (v*)