### PR TITLE
Add resample_signal to signals.tools module

### DIFF
--- a/biosppy/signals/tools.py
+++ b/biosppy/signals/tools.py
@@ -2266,3 +2266,31 @@ def detrend_smoothness_priors(signal, smoothing_factor=10):
     z_detrended = np.array(signal) - z_trend
 
     return utils.ReturnTuple((z_detrended.T, z_trend.T), ('detrended', 'trend'))
+
+
+def resample_signal(signal, sampling_rate, resampling_rate):
+    """
+    Resample a signal to a new sampling frequency. It assumes that the input signal is uniformly sampled.
+
+    Parameters
+    ----------
+    signal : array-like
+        The signal to resample.
+    sampling_rate : float
+        The original sampling frequency of the signal.
+    resampling_rate : float
+        The new sampling frequency.
+
+    Returns
+    -------
+    resampled_signal : array-like
+        The resampled signal.
+    """
+
+    # check inputs
+    if signal is None:
+        raise TypeError("Please specify a signal to resample.")
+
+    resampled_signal = ss.resample(signal, int(len(signal) * resampling_rate / sampling_rate))
+
+    return utils.ReturnTuple((resampled_signal,), ('signal',))


### PR DESCRIPTION
This PR adds the `resample_signal` function to the `signals.tools` module.

The function allows resampling of a signal from its original sampling rate to a new target sampling rate using scipy.signal.resample, by calculating required number of output samples with the original and new sampling frequencies. It supports both single- and multi-channel inputs.

### Working Example

```python
from biosppy storage, signals

# load ecg signal from examples
ecg_signal, mdata = storage.load_txt('examples/ecg.txt')

# resample the signal to 500 Hz
resampled_ecg, = signals.tools.resample_signal(ecg_signal, mdata['sampling_rate'], 500.0)